### PR TITLE
Add Flask web dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ Launch the dashboard:
 python battleship_dashboard.py
 ```
 
+You can also run the lightweight Flask web interface:
+```bash
+python webapp/app.py
+```
+
 ### Dashboard Tabs
 1. **Game** – play individual games or human vs. AI
 2. **Batch Simulation** – run many games for benchmarking

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ scikit-learn>=0.24.0
 pillow>=8.0.0
 customtkinter>=4.6.0
 tqdm>=4.50.0
+Flask>=2.0.0

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,0 +1,103 @@
+from flask import Flask, render_template, request, jsonify, redirect, url_for
+from pathlib import Path
+import json
+
+import sys
+BASE_DIR = Path(__file__).resolve().parents[1]
+if str(BASE_DIR) not in sys.path:
+    sys.path.append(str(BASE_DIR))
+
+from battleship_dashboard import GameEngine, AnalyticsManager, AGENT_CLASSES
+
+app = Flask(__name__)
+
+# Global engine and analytics objects
+engine = GameEngine()
+analytics = AnalyticsManager()
+
+# Helper to serialise board for front-end
+
+def board_to_matrix(board, reveal=False):
+    size = board.size
+    matrix = []
+    for r in range(size):
+        row = []
+        for c in range(size):
+            val = board.grid[r, c]
+            cell = val
+            if reveal and (r, c) in board.ship_lookup:
+                cell = 3  # ship
+            row.append(cell)
+        matrix.append(row)
+    return matrix
+
+@app.route('/')
+def index():
+    return redirect(url_for('game'))
+
+@app.route('/game', methods=['GET', 'POST'])
+def game():
+    if request.method == 'POST':
+        p1 = request.form.get('player1', 'Human')
+        p2 = request.form.get('player2', 'AI_agent4')
+        engine.setup_game(p1, p2)
+        return redirect(url_for('play'))
+    return render_template('game.html', agents=AGENT_CLASSES.keys())
+
+@app.route('/play')
+def play():
+    if not engine.player1:
+        return redirect(url_for('game'))
+    board = board_to_matrix(engine.opponent.board, reveal=False)
+    return render_template('play.html', board=board)
+
+@app.route('/move', methods=['POST'])
+def move():
+    data = request.get_json(force=True)
+    r = int(data['row'])
+    c = int(data['col'])
+    result = engine.make_move(r, c)
+    board_current = board_to_matrix(engine.opponent.board, reveal=False)
+    over = engine.game_over
+    winner = engine.winner.name if over else None
+    return jsonify({'result': result, 'board': board_current, 'game_over': over, 'winner': winner})
+
+@app.route('/ai_move')
+def ai_move():
+    if engine.game_over:
+        return jsonify({'game_over': True})
+    res = engine.ai_move()
+    board_current = board_to_matrix(engine.opponent.board, reveal=False)
+    over = engine.game_over
+    winner = engine.winner.name if over else None
+    return jsonify({'result': res, 'board': board_current, 'game_over': over, 'winner': winner})
+
+@app.route('/batch', methods=['GET', 'POST'])
+def batch():
+    if request.method == 'POST':
+        p1 = request.form.get('player1')
+        p2 = request.form.get('player2')
+        n = int(request.form.get('games', 10))
+        stats = []
+        def progress(current, total, batch_stats, finished=False):
+            stats.append(batch_stats.copy())
+        engine.run_batch_simulation(p1, p2, n, progress)
+        while engine.simulation_thread and engine.simulation_thread.is_alive():
+            pass
+        summary = stats[-1] if stats else engine.batch_stats
+        return render_template('batch.html', agents=AGENT_CLASSES.keys(), summary=summary)
+    return render_template('batch.html', agents=AGENT_CLASSES.keys())
+
+@app.route('/analytics')
+def analytics_view():
+    summary = analytics.get_performance_summary()
+    if not summary:
+        summary = {'total_games': 0, 'player_stats': {}, 'avg_moves': {}}
+    return render_template('analytics.html', summary=json.dumps(summary))
+
+@app.route('/settings')
+def settings():
+    return render_template('settings.html')
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -1,0 +1,18 @@
+.board {
+  display: grid;
+  grid-template-columns: repeat(10, 30px);
+  grid-template-rows: repeat(10, 30px);
+  gap: 2px;
+}
+.cell {
+  width: 30px;
+  height: 30px;
+  border: 1px solid #ccc;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+.cell.hit { background: #FF4C4C; color: white; }
+.cell.miss { background: #4C72B0; color: white; }
+.cell.ship { background: #808080; }

--- a/webapp/templates/analytics.html
+++ b/webapp/templates/analytics.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Analytics</h2>
+<pre id="summary"></pre>
+<script>
+const summary = JSON.parse('{{ summary|safe }}');
+const pre = document.getElementById('summary');
+pre.textContent = JSON.stringify(summary, null, 2);
+</script>
+{% endblock %}

--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Battleship Dashboard</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+  </head>
+  <body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="{{ url_for('game') }}">Battleship</a>
+        <div class="collapse navbar-collapse">
+          <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+            <li class="nav-item"><a class="nav-link" href="{{ url_for('game') }}">Game</a></li>
+            <li class="nav-item"><a class="nav-link" href="{{ url_for('batch') }}">Batch Simulation</a></li>
+            <li class="nav-item"><a class="nav-link" href="{{ url_for('analytics_view') }}">Analytics</a></li>
+            <li class="nav-item"><a class="nav-link" href="{{ url_for('settings') }}">Settings</a></li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+    <div class="container mt-4">
+      {% block content %}{% endblock %}
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  </body>
+</html>

--- a/webapp/templates/batch.html
+++ b/webapp/templates/batch.html
@@ -1,0 +1,31 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Batch Simulation</h2>
+<form method="post">
+  <div class="row mb-3">
+    <div class="col">
+      <label class="form-label">Player 1</label>
+      <select name="player1" class="form-select">
+        {% for a in agents %}<option value="{{a}}">{{a}}</option>{% endfor %}
+      </select>
+    </div>
+    <div class="col">
+      <label class="form-label">Player 2</label>
+      <select name="player2" class="form-select">
+        {% for a in agents %}<option value="{{a}}">{{a}}</option>{% endfor %}
+      </select>
+    </div>
+    <div class="col">
+      <label class="form-label">Games</label>
+      <input type="number" name="games" value="10" class="form-control">
+    </div>
+  </div>
+  <button class="btn btn-primary">Run Simulation</button>
+</form>
+{% if summary %}
+<div class="mt-4">
+  <h5>Summary</h5>
+  <pre>{{ summary }}</pre>
+</div>
+{% endif %}
+{% endblock %}

--- a/webapp/templates/game.html
+++ b/webapp/templates/game.html
@@ -1,0 +1,25 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>New Game</h2>
+<form method="post">
+  <div class="row mb-3">
+    <div class="col">
+      <label class="form-label">Player 1</label>
+      <select name="player1" class="form-select">
+        {% for a in agents %}
+        <option value="{{ a }}">{{ a }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="col">
+      <label class="form-label">Player 2</label>
+      <select name="player2" class="form-select">
+        {% for a in agents %}
+        <option value="{{ a }}">{{ a }}</option>
+        {% endfor %}
+      </select>
+    </div>
+  </div>
+  <button class="btn btn-primary">Start Game</button>
+</form>
+{% endblock %}

--- a/webapp/templates/play.html
+++ b/webapp/templates/play.html
@@ -1,0 +1,33 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Play</h2>
+<div id="board" class="board"></div>
+<div class="mt-3">
+  <button class="btn btn-secondary" onclick="aiMove()">AI Move</button>
+</div>
+<script>
+const board = {{ board|tojson }};
+function render(){
+  const el = document.getElementById('board');
+  el.innerHTML = '';
+  board.forEach((row,r)=>{
+    row.forEach((cell,c)=>{
+      const div = document.createElement('div');
+      div.className='cell';
+      if(cell==1) div.classList.add('miss');
+      if(cell==2) div.classList.add('hit');
+      div.onclick=()=>shoot(r,c);
+      el.appendChild(div);
+    });
+  });
+}
+function shoot(r,c){
+  fetch('/move',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({row:r,col:c})})
+  .then(r=>r.json()).then(data=>{Object.assign(board,data.board);render();if(data.game_over)alert('Winner: '+data.winner);});
+}
+function aiMove(){
+  fetch('/ai_move').then(r=>r.json()).then(data=>{if(data.board){Object.assign(board,data.board);}render();if(data.game_over)alert('Winner: '+data.winner);});
+}
+render();
+</script>
+{% endblock %}

--- a/webapp/templates/settings.html
+++ b/webapp/templates/settings.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Settings</h2>
+<p>Settings placeholder.</p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- build basic Flask web app for Battleship dashboard
- add HTML templates and simple interactive board
- include minimal Bootstrap styling
- update requirements with Flask
- document how to launch the web app

## Testing
- `pip install -r requirements.txt`
- `python webapp/app.py` *(server started with TensorFlow warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684254a9de8483278e3056ebdb8dbb2a